### PR TITLE
additional patches

### DIFF
--- a/GameData/EvaFuel/MM_Patches/AddPodMonoPropollant.cfg
+++ b/GameData/EvaFuel/MM_Patches/AddPodMonoPropollant.cfg
@@ -1,0 +1,24 @@
+// AddPodMonoPropollant.cfg v1.0
+// EvaFuel
+// created: 27 Oct 19
+// updated: 27 Oct 19
+
+@PART[*]:HAS[#CrewCapacity[>0]]:NEEDS[EvaFuel]:FOR[EvaFuel]
+{
+	@description ^= :(.)$:$0\n<color=orange>MonoPropellant. </color>:
+
+	@RESOURCE[MonoPropellant] // [MonoPropellant]
+	{
+	 // Edit or create if it doesn't already exist
+		&maxAmount = 5 // Set value if it doesn't exist already
+	// Increase amount of existing EC based upon CrewCapacity
+		%amount = #$../CrewCapacity$ // Set the value whether or not it exists
+		@amount *= 10
+		@amount += #$maxAmount$
+		@amount ^= :(\.\d)\d+$:$1: // keep only 1 decimal place
+		@maxAmount = #$amount$
+	}
+}
+
+// CC BY-NC-SA-4.0
+// zer0Kerbal

--- a/GameData/EvaFuel/MM_Patches/ConvertEVATanktoMonoPropellant.cfg
+++ b/GameData/EvaFuel/MM_Patches/ConvertEVATanktoMonoPropellant.cfg
@@ -1,0 +1,15 @@
+// ConvertEVATanktoMonoPropellant.cfg v1.0
+// EvaFuel
+// created: 01 Jul 18
+// updated: 27 Oct 19
+
+@PART[KIS_evapropellant]:NEEDS[KIS,EvaFuel]:FOR[EvaFuel]
+{
+	@RESOURCE[EVA?Propellant]
+	{
+		@name = MonoPropellant
+	}
+}
+
+// CC BY-NC-SA-4.0
+// zer0Kerbal


### PR DESCRIPTION
- make sure all Pods(crewCapacity>0) (should also include pods in rescue contracts) have at least 5 units of MonoPropellant
- Converts KIS EVATank[KIS_evapropellant] to use/contain MonoPropellant